### PR TITLE
Multiple imports on the same line

### DIFF
--- a/tests/import_obj_test.py
+++ b/tests/import_obj_test.py
@@ -266,7 +266,9 @@ def test_local_imports(input_str):
     ('input_str', 'expected'),
     (
         ('from foo import bar', FromImport.from_str('from foo import bar')),
+        ('from foo import bar, baz', FromImport.from_str('from foo import bar, baz')),
         ('import bar', ImportImport.from_str('import bar')),
+        ('import bar, baz', ImportImport.from_str('import bar, baz')),
     ),
 )
 def test_import_obj_from_str(input_str, expected):


### PR DESCRIPTION
It seems I need this for the issue I opened yesterday on [reorder_python_imports](https://github.com/asottile/reorder_python_imports/issues/8) regarding multiple imports on one line.

Let me know what you think, I guess it's pretty aggressive though :)

I removed the restriction on ``ImportImport`` as well as it is possible and legal to do (Although pep8 disapproves).
*I seem to have read somewhere that you should follow the pep but it's okay not to, or something like that, somehwere, can't for the life of me find now though* 