### PR TITLE
Add separate_relative argument to sort function

### DIFF
--- a/aspy/refactor_imports/classify.py
+++ b/aspy/refactor_imports/classify.py
@@ -11,8 +11,9 @@ class ImportType(object):
     BUILTIN = 'BUILTIN'
     THIRD_PARTY = 'THIRD_PARTY'
     APPLICATION = 'APPLICATION'
+    RELATIVE = "RELATIVE"
 
-    __all__ = (FUTURE, BUILTIN, THIRD_PARTY, APPLICATION)
+    __all__ = (FUTURE, BUILTIN, THIRD_PARTY, APPLICATION, RELATIVE)
 
 
 def _pythonpath_dirs():
@@ -104,7 +105,8 @@ def _get_module_info(module_name, application_directories):
 PACKAGES_PATH = '-packages' + os.sep
 
 
-def classify_import(module_name, application_directories=('.',)):
+def classify_import(module_name, application_directories=('.',),
+                    separate_relative=False):
     """Classifies an import by its package.
 
     Returns a value in ImportType.__all__
@@ -112,6 +114,8 @@ def classify_import(module_name, application_directories=('.',)):
     :param text module_name: The dotted notation of a module
     :param tuple application_directories: tuple of paths which are considered
         application roots.
+    :param bool separate_relative:
+        Split relative imports from application imports.
     """
     # Only really care about the first part of the path
     base_module_name = module_name.split('.')[0]
@@ -122,7 +126,10 @@ def classify_import(module_name, application_directories=('.',)):
     if base_module_name == '__future__':
         return ImportType.FUTURE
     elif base_module_name == '':
-        return ImportType.APPLICATION
+        if separate_relative:
+            return ImportType.RELATIVE
+        else:
+            return ImportType.APPLICATION
     # If imp tells us it is builtin, it is builtin
     elif module_info[2] == imp.C_BUILTIN:
         return ImportType.BUILTIN

--- a/aspy/refactor_imports/sort.py
+++ b/aspy/refactor_imports/sort.py
@@ -16,7 +16,8 @@ CLS_TO_INDEX = {
 }
 
 
-def sort(imports, separate=True, import_before_from=True, **classify_kwargs):
+def sort(imports, separate=True, import_before_from=True,
+         separate_relative=False, **classify_kwargs):
     """Sort import objects into groups.
 
     :param list imports: FromImport / ImportImport objects
@@ -24,6 +25,9 @@ def sort(imports, separate=True, import_before_from=True, **classify_kwargs):
         of imports based on classification.
     :param bool import_before_from: Whether to sort `import ...` imports before
         `from ...` imports.
+    :param bool split_relative:
+        Whether to split `from .xx import xx` imports from other local imports
+        with an new line.
 
     For example:
         from os import path
@@ -62,7 +66,38 @@ def sort(imports, separate=True, import_before_from=True, **classify_kwargs):
         from os import path
         import pyramid
         import sys
+
+    Split relative example:
+
+        from os import path
+        from aspy import refactor_imports
+        from .sort import sort
+        import sys
+        import pyramid
+
+    sperate = True, import_before_from = True, separate_relative = False
+
+        import sys
+        from os import path
+
+        import pyramid
+
+        from .sort import sort
+        from aspy import refactor_imports
+
+    sperate = True, import_before_from = True, separate_relative = True
+
+        import sys
+        from os import path
+
+        import pyramid
+
+        from aspy import refactor_imports
+
+        from .sort import sort
     """
+    classify_kwargs["separate_relative"] = separate_relative
+
     if separate:
         def classify_func(obj):
             return classify_import(

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -13,6 +13,10 @@ IMPORTS = (
     ImportImport.from_str('import pyramid'),
 )
 
+RELATIVE_IMPORTS = IMPORTS + (
+    FromImport.from_str("from .sort import sort"),
+)
+
 
 def test_separate_import_before_from():
     ret = sort(IMPORTS, separate=True, import_before_from=True)
@@ -104,3 +108,37 @@ def test_passes_through_kwargs_to_classify(in_tmpdir, no_empty_path):
     # it'll be third party (and in the same group as pyramid)
     ret = sort(imports, application_directories=('dne',))
     assert ret == (imports,)
+
+
+def test_separate_relative():
+    ret = sort(RELATIVE_IMPORTS)
+    assert ret == (
+        (
+            ImportImport.from_str('import sys'),
+            FromImport.from_str('from os import path'),
+        ),
+        (
+            ImportImport.from_str('import pyramid'),
+        ),
+        (
+            FromImport.from_str('from .sort import sort'),
+            FromImport.from_str('from aspy import refactor_imports'),
+        ),
+    )
+
+    ret = sort(RELATIVE_IMPORTS, separate_relative=True)
+    assert ret == (
+        (
+            ImportImport.from_str('import sys'),
+            FromImport.from_str('from os import path'),
+        ),
+        (
+            ImportImport.from_str('import pyramid'),
+        ),
+        (
+            FromImport.from_str('from aspy import refactor_imports'),
+        ),
+        (
+            FromImport.from_str('from .sort import sort'),
+        )
+    )


### PR DESCRIPTION
To support split relative imports from local imports with an new line.

Closes #17.
Prepare for asottile/reorder_python_imports#20.