### PR TITLE
Add is_explicit_relative property in AbstractImportObj

### DIFF
--- a/aspy/refactor_imports/import_obj.py
+++ b/aspy/refactor_imports/import_obj.py
@@ -41,6 +41,11 @@ class AbstractImportObj(object):
         return self._sort_key_type.from_python_ast(self.ast_obj)
 
     @cached_property
+    def is_explicit_relative(self):
+        """Returns True if this import is relative."""
+        return self.import_statement.module.startswith('.')
+
+    @cached_property
     def sort_key(self):
         return namedtuple_lower(self.import_statement) + self.import_statement
 

--- a/tests/import_obj_test.py
+++ b/tests/import_obj_test.py
@@ -282,3 +282,15 @@ def test_local_imports(input_str):
 )
 def test_import_obj_from_str(input_str, expected):
     assert import_obj_from_str(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    ('input_str', 'expected'),
+    (
+        ('import bar', False),
+        ('from foo import bar', False),
+        ('from .foo import bar', True),
+    )
+)
+def test_is_explicit_relative(input_str, expected):
+    assert import_obj_from_str(input_str).is_explicit_relative is expected


### PR DESCRIPTION
Related PR: #18.
Closes #17.
Prepare for asottile/reorder_python_imports#20.