### PR TITLE
Add backports support

### DIFF
--- a/aspy/refactor_imports/classify.py
+++ b/aspy/refactor_imports/classify.py
@@ -121,7 +121,8 @@ else:  # pragma: no cover (PY3+)
 PACKAGES_PATH = '-packages' + os.sep
 
 
-def classify_import(module_name, application_directories=('.',)):
+def classify_import(module_name, application_directories=('.',),
+                    backports=None):
     """Classifies an import by its package.
 
     Returns a value in ImportType.__all__
@@ -129,6 +130,8 @@ def classify_import(module_name, application_directories=('.',)):
     :param text module_name: The dotted notation of a module
     :param tuple application_directories: tuple of paths which are considered
         application roots.
+    :param set backports: A set of first part of modules that should be
+        classified as BUILTIN.
     """
     # Only really care about the first part of the path
     base, _, _ = module_name.partition('.')
@@ -153,6 +156,7 @@ def classify_import(module_name, application_directories=('.',)):
             found and
             PACKAGES_PATH not in module_path and
             not _due_to_pythonpath(module_path)
+            or backports is not None and base in backports
     ):
         return ImportType.BUILTIN
     else:

--- a/tests/classify_test.py
+++ b/tests/classify_test.py
@@ -97,6 +97,11 @@ def test_empty_directory_is_not_package(in_tmpdir, no_empty_path):
     assert ret is ImportType.THIRD_PARTY
 
 
+def test_backport_is_builtin(in_tmpdir, no_empty_path):
+    ret = classify_import('backported', backports={'backported'})
+    assert ret is ImportType.BUILTIN
+
+
 def test_application_directories(in_tmpdir, no_empty_path):
     # Similar to @bukzor's testing setup
     in_tmpdir.join('tests/testing').ensure_dir().join('__init__.py').ensure()


### PR DESCRIPTION
Since `dataclasses` doesn't exist before 3.7 so I use a backport library of it https://github.com/ericvsmith/dataclasses to support from python 3.6 to python 3.8. However, `classify_import` on `dataclasses` on python 3.6 returns different import `ImportType` (`THIRD_PARTY`) from the value that is returned by 3.7 (`BUILTIN`), so the sort order is different between python versions. I thought that the `backport` option can pin them as `BUILTIN`s and fix the situation.