### PR TITLE
Add application_modules argument to classify

### DIFF
--- a/aspy/refactor_imports/classify.py
+++ b/aspy/refactor_imports/classify.py
@@ -2,6 +2,7 @@ import importlib.util
 import os.path
 import sys
 import zipimport
+from typing import Container
 from typing import Set
 from typing import Tuple
 
@@ -97,6 +98,7 @@ PACKAGES_PATH = '-packages' + os.sep
 def classify_import(
         module_name: str,
         application_directories: Tuple[str, ...] = ('.',),
+        unclassifiable_application_modules: Container[str] = (),
 ) -> str:
     """Classifies an import by its package.
 
@@ -105,6 +107,10 @@ def classify_import(
     :param text module_name: The dotted notation of a module
     :param tuple application_directories: tuple of paths which are considered
         application roots.
+    :param tuple unclassifiable_application_modules: tuple of module names
+        that are considered application modules.  this setting is intended
+        to be used for things like C modules which may not always appear on
+        the filesystem.
     """
     # Only really care about the first part of the path
     base, _, _ = module_name.partition('.')
@@ -113,6 +119,8 @@ def classify_import(
     )
     if base == '__future__':
         return ImportType.FUTURE
+    elif base in unclassifiable_application_modules:
+        return ImportType.APPLICATION
     # Relative imports: `from .foo import bar`
     elif base == '':
         return ImportType.APPLICATION

--- a/tests/classify_test.py
+++ b/tests/classify_test.py
@@ -128,3 +128,22 @@ def test_application_directories(in_tmpdir, no_empty_path):
     # Should be application with extra directories
     ret = classify_import('testing', application_directories=('.', 'tests'))
     assert ret is ImportType.APPLICATION
+
+
+def test_unclassifiable_application_modules():
+    # Should be classified 3rd party without argument
+    ret = classify_import('c_module')
+    assert ret is ImportType.THIRD_PARTY
+    # Should be classified application with the override
+    ret = classify_import(
+        'c_module', unclassifiable_application_modules=('c_module',),
+    )
+    assert ret is ImportType.APPLICATION
+
+
+def test_unclassifiable_application_modules_ignores_future():
+    # Trying to force __future__ to be APPLICATION shouldn't have any effect
+    ret = classify_import(
+        '__future__', unclassifiable_application_modules=('__future__',),
+    )
+    assert ret is ImportType.FUTURE


### PR DESCRIPTION
As suggested in https://github.com/asottile/reorder_python_imports/pull/123 I've added an option to override classification.