### PR TITLE
Don't build universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,6 @@ exclude =
     tests*
     testing*
 
-[bdist_wheel]
-universal = True
-
 [coverage:run]
 plugins = covdefaults
 


### PR DESCRIPTION
This package is no longer compatible with python 2, so it should not be a universal wheel.