### PR TITLE
Fix classification of application as builtin on Windows

### DIFF
--- a/tests/classify_test.py
+++ b/tests/classify_test.py
@@ -130,6 +130,18 @@ def test_application_directories(in_tmpdir, no_empty_path):
     assert ret is ImportType.APPLICATION
 
 
+@pytest.mark.xfail(
+    sys.platform != 'win32',
+    reason='Expected fail due to case-sensitive os.path.commonpath',
+)
+def test_application_directory_case(in_tmpdir, no_empty_path):
+    srcdir = in_tmpdir.join('SRC').ensure_dir()
+    srcdir.join('my_package').ensure_dir().join('__init__.py').ensure()
+    with in_sys_path('src'):
+        ret = classify_import('my_package', application_directories=('SRC',))
+    assert ret is ImportType.APPLICATION
+
+
 def test_unclassifiable_application_modules():
     # Should be classified 3rd party without argument
     ret = classify_import('c_module')


### PR DESCRIPTION
This fixes a bug on Windows, where under certain circumstances an application is misclassified as a builtin, due to case-sensitive path comparison on a case-insensitive filesystem. See #52 for more details.

Closes #52 

**Proposed fixes**

- Compute the common path prefix of the module path and the application directory, using `os.path.commonpath`. Check if this path prefix is the same directory as the application directory, using ~`os.path.samefile`~ `os.path.normcase`.

- Handle the case where the module path is on a different drive than the application directory. The `os.path.commonpath` function raises `ValueError` if the paths are on different drives.

- Use ~`os.path.samefile`~ `os.path.normcase` to check if the real and absolute paths of the module are the same directory.

**Tests**

The test case uses an application directory named `SRC` and a `sys.path` entry of `src`. This is slightly different from the real world case described in the issue, but suffices to reproduce the issue. The test case is marked xfail on Linux, because this platform typically uses case-sensitive file systems.

Surprisingly (at least to me), the test case also needs to be marked xfail on macOS, even though this platform is traditionally case-insensitive. The reason for this is that `os.path.commonpath` is case-sensitive on macOS (arguably a bug in CPython?).

There is no test case yet for the branch where module path and application directory are on different drives, because I have not come up with a good way to test this.