### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,12 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:

--- a/aspy/__init__.py
+++ b/aspy/__init__.py
@@ -1,2 +1,3 @@
 # This is a namespace package
+from __future__ import annotations
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)

--- a/aspy/refactor_imports/sort.py
+++ b/aspy/refactor_imports/sort.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 import collections
 from typing import Any
-from typing import Dict
-from typing import List
 from typing import Sequence
-from typing import Tuple
 
 from aspy.refactor_imports.classify import classify_import
 from aspy.refactor_imports.classify import ImportType
@@ -21,7 +20,7 @@ def sort(
         separate: bool = True,
         import_before_from: bool = True,
         **kwargs: Any,
-) -> Tuple[Tuple[AbstractImportObj, ...], ...]:
+) -> tuple[tuple[AbstractImportObj, ...], ...]:
     """Sort import objects into groups.
 
     :param list imports: FromImport / ImportImport objects
@@ -71,7 +70,7 @@ def sort(
     if separate:
         def classify_func(obj: AbstractImportObj) -> str:
             return classify_import(obj.import_statement.module, **kwargs)
-        types: Tuple[str, ...] = ImportType.__all__
+        types: tuple[str, ...] = ImportType.__all__
     else:
         # A little cheaty, this allows future imports to sort before others
         def classify_func(obj: AbstractImportObj) -> str:
@@ -83,14 +82,14 @@ def sort(
         types = (ImportType.FUTURE, '(not future)')
 
     if import_before_from:
-        def sort_within(obj: AbstractImportObj) -> Tuple[str, ...]:
+        def sort_within(obj: AbstractImportObj) -> tuple[str, ...]:
             return (CLS_TO_INDEX[type(obj)],) + obj.sort_key
     else:
-        def sort_within(obj: AbstractImportObj) -> Tuple[str, ...]:
+        def sort_within(obj: AbstractImportObj) -> tuple[str, ...]:
             return tuple(obj.sort_key)
 
     # Partition the imports
-    imports_partitioned: Dict[str, List[AbstractImportObj]]
+    imports_partitioned: dict[str, list[AbstractImportObj]]
     imports_partitioned = collections.defaultdict(list)
     for import_obj in imports:
         imports_partitioned[classify_func(import_obj)].append(import_obj)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
@@ -19,5 +19,5 @@ jobs:
     os: windows
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38]
+    toxenvs: [py37, py38, py39, py310]
     os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -26,7 +25,7 @@ classifiers =
 packages = find:
 install_requires =
     cached-property
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.packages.find]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/classify_test.py
+++ b/tests/classify_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import os.path
 import subprocess

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/import_obj_test.py
+++ b/tests/import_obj_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import re
 

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from aspy.refactor_imports.import_obj import FromImport
 from aspy.refactor_imports.import_obj import ImportImport
 from aspy.refactor_imports.sort import sort

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,pypy3,pre-commit
+envlist = py37,py38,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos