### PR TITLE
Always sort 'from __future__' imports first

### DIFF
--- a/aspy/refactor_imports/sort.py
+++ b/aspy/refactor_imports/sort.py
@@ -69,7 +69,10 @@ def sort(
     """
     if separate:
         def classify_func(obj: AbstractImportObj) -> str:
-            return classify_import(obj.import_statement.module, **kwargs)
+            tp = classify_import(obj.import_statement.module, **kwargs)
+            if tp == ImportType.FUTURE and isinstance(obj, ImportImport):
+                tp = ImportType.BUILTIN
+            return tp
         types: tuple[str, ...] = ImportType.__all__
     else:
         # A little cheaty, this allows future imports to sort before others

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -84,6 +84,19 @@ def test_future_separate_block_non_separate():
     )
 
 
+def test_future_from_always_first():
+    ret = sort(
+        (
+            FromImport.from_str('from __future__ import absolute_import'),
+            ImportImport.from_str('import __future__'),
+        ),
+    )
+    assert ret == (
+        (FromImport.from_str('from __future__ import absolute_import'),),
+        (ImportImport.from_str('import __future__'),),
+    )
+
+
 def test_passes_through_kwargs_to_classify(in_tmpdir, no_empty_path):
     # Make a module
     in_tmpdir.join('my_module.py').ensure()


### PR DESCRIPTION
Fixes https://github.com/asottile/reorder_python_imports/issues/214 .