### PR TITLE
Always sort 'from __future__' imports first (alternative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,16 +88,20 @@ Utilities for refactoring imports in python-like syntax.
 #### Classify a module
 
 ```python
+>>> from aspy.refactor_imports.import_obj import FromImport
+>>> from aspy.refactor_imports.import_obj import ImportImport
 >>> from aspy.refactor_imports.classify import classify_import
->>> classify_import('__future__')
+>>> classify_import(FromImport.from_str('from __future__ import annotations'))
 'FUTURE'
->>> classify_import('aspy')
-'APPLICATION'
->>> classify_import('pyramid')
-'THIRD_PARTY'
->>> classify_import('os')
+>>> classify_import(ImportImport.from_str('import __future__'))
 'BUILTIN'
->>> classify_import('os.path')
+>>> classify_import(ImportImport.from_str('import aspy'))
+'APPLICATION'
+>>> classify_import(ImportImport.from_str('import pyramid'))
+'THIRD_PARTY'
+>>> classify_import(ImportImport.from_str('import os'))
+'BUILTIN'
+>>> classify_import(FromImport.from_str('from os.path import basename'))
 'BUILTIN'
 ```
 
@@ -107,7 +111,7 @@ Utilities for refactoring imports in python-like syntax.
 ## From aspy.refactor_imports.classify
 
 
-class ImportType(object):
+class ImportType:
     __slots__ = ()
 
     FUTURE = 'FUTURE'

--- a/aspy/refactor_imports/classify.py
+++ b/aspy/refactor_imports/classify.py
@@ -6,6 +6,9 @@ import sys
 import zipimport
 from typing import Container
 
+from aspy.refactor_imports.import_obj import AbstractImportObj
+from aspy.refactor_imports.import_obj import FromImport
+
 
 class ImportType:
     __slots__ = ()
@@ -114,7 +117,7 @@ PACKAGES_PATH = '-packages' + os.sep
 
 
 def classify_import(
-        module_name: str,
+        import_obj: AbstractImportObj,
         application_directories: tuple[str, ...] = ('.',),
         unclassifiable_application_modules: Container[str] = (),
 ) -> str:
@@ -131,12 +134,15 @@ def classify_import(
         the filesystem.
     """
     # Only really care about the first part of the path
-    base, _, _ = module_name.partition('.')
+    base, _, _ = import_obj.import_statement.module.partition('.')
     found, module_path, is_builtin = _get_module_info(
         base, application_directories,
     )
     if base == '__future__':
-        return ImportType.FUTURE
+        if isinstance(import_obj, FromImport):
+            return ImportType.FUTURE
+        else:
+            return ImportType.BUILTIN
     elif base == '__main__':
         return ImportType.APPLICATION
     elif base in unclassifiable_application_modules:

--- a/aspy/refactor_imports/sort.py
+++ b/aspy/refactor_imports/sort.py
@@ -69,12 +69,12 @@ def sort(
     """
     if separate:
         def classify_func(obj: AbstractImportObj) -> str:
-            return classify_import(obj.import_statement.module, **kwargs)
+            return classify_import(obj, **kwargs)
         types: tuple[str, ...] = ImportType.__all__
     else:
         # A little cheaty, this allows future imports to sort before others
         def classify_func(obj: AbstractImportObj) -> str:
-            tp = classify_import(obj.import_statement.module, **kwargs)
+            tp = classify_import(obj, **kwargs)
             if tp == ImportType.FUTURE:
                 return ImportType.FUTURE
             else:

--- a/tests/classify_test.py
+++ b/tests/classify_test.py
@@ -10,6 +10,8 @@ from unittest import mock
 import pytest
 from aspy.refactor_imports.classify import classify_import
 from aspy.refactor_imports.classify import ImportType
+from aspy.refactor_imports.import_obj import FromImport
+from aspy.refactor_imports.import_obj import ImportImport
 
 
 @pytest.mark.parametrize(
@@ -27,7 +29,7 @@ from aspy.refactor_imports.classify import ImportType
     ),
 )
 def test_classify_import(module, expected):
-    ret = classify_import(module)
+    ret = classify_import(FromImport.from_str(f'from {module} import foo'))
     assert ret is expected
 
 
@@ -36,15 +38,17 @@ def test_spec_is_none():
     prog = '''\
 import __main__
 from aspy.refactor_imports.classify import classify_import, ImportType
+from aspy.refactor_imports.import_obj import ImportImport
 assert __main__.__spec__ is None, __main__.__spec__
-tp = classify_import('__main__')
+tp = classify_import(ImportImport.from_str('import __main__'))
 assert tp == ImportType.APPLICATION, tp
 '''
     subprocess.check_call((sys.executable, '-c', prog))
 
     # simulate this situation for coverage
     with mock.patch.object(sys.modules['__main__'], '__spec__', None):
-        assert classify_import('__main__') == ImportType.APPLICATION
+        import_obj = ImportImport.from_str('import __main__')
+        assert classify_import(import_obj) == ImportType.APPLICATION
 
 
 def test_true_namespace_package(tmpdir):
@@ -54,7 +58,8 @@ def test_true_namespace_package(tmpdir):
     with mock.patch.object(sys, 'path', sys_path):
         # while this is a py3+ feature, aspy.refactor_imports happens to get
         # this correct anyway!
-        assert classify_import('a') == ImportType.THIRD_PARTY
+        import_obj = ImportImport.from_str('import a')
+        assert classify_import(import_obj) == ImportType.THIRD_PARTY
 
 
 @pytest.mark.xfail(  # pragma: win32 no cover
@@ -65,7 +70,7 @@ def test_symlink_path_different(in_tmpdir, no_empty_path):
     # symlink a file, these are likely to not be application files
     in_tmpdir.join('dest_file.py').ensure()
     in_tmpdir.join('src_file.py').mksymlinkto('dest-file.py')
-    ret = classify_import('src_file')
+    ret = classify_import(ImportImport.from_str('import src_file'))
     assert ret is ImportType.THIRD_PARTY
 
 
@@ -90,19 +95,22 @@ def in_sys_path_and_pythonpath(pth):
 def test_classify_pythonpath_third_party(in_tmpdir):
     in_tmpdir.join('ppth').ensure_dir().join('f.py').ensure()
     with in_sys_path_and_pythonpath('ppth'):
-        assert classify_import('f') is ImportType.THIRD_PARTY
+        import_obj = ImportImport.from_str('import f')
+        assert classify_import(import_obj) is ImportType.THIRD_PARTY
 
 
 def test_classify_pythonpath_dot_app(in_tmpdir):
     in_tmpdir.join('f.py').ensure()
     with in_sys_path_and_pythonpath('.'):
-        assert classify_import('f') is ImportType.APPLICATION
+        import_obj = ImportImport.from_str('import f')
+        assert classify_import(import_obj) is ImportType.APPLICATION
 
 
 def test_classify_pythonpath_multiple(in_tmpdir):
     in_tmpdir.join('ppth').ensure_dir().join('f.py').ensure()
     with in_sys_path_and_pythonpath(os.pathsep.join(('ppth', 'foo'))):
-        assert classify_import('f') is ImportType.THIRD_PARTY
+        import_obj = ImportImport.from_str('import f')
+        assert classify_import(import_obj) is ImportType.THIRD_PARTY
 
 
 def test_classify_pythonpath_zipimport(in_tmpdir):
@@ -110,7 +118,8 @@ def test_classify_pythonpath_zipimport(in_tmpdir):
     with zipfile.ZipFile(str(path_zip), 'w') as fzip:
         fzip.writestr('fzip.py', '')
     with in_sys_path_and_pythonpath('ppth/fzip.zip'):
-        assert classify_import('fzip') is ImportType.THIRD_PARTY
+        import_obj = ImportImport.from_str('import fzip')
+        assert classify_import(import_obj) is ImportType.THIRD_PARTY
 
 
 def test_classify_embedded_builtin(in_tmpdir):
@@ -118,24 +127,25 @@ def test_classify_embedded_builtin(in_tmpdir):
     with zipfile.ZipFile(str(path_zip), 'w') as fzip:
         fzip.writestr('fzip.py', '')
     with in_sys_path('ppth/fzip.zip'):
-        assert classify_import('fzip') is ImportType.BUILTIN
+        import_obj = ImportImport.from_str('import fzip')
+        assert classify_import(import_obj) is ImportType.BUILTIN
 
 
 def test_file_existing_is_application_level(in_tmpdir, no_empty_path):
     in_tmpdir.join('my_file.py').ensure()
-    ret = classify_import('my_file')
+    ret = classify_import(ImportImport.from_str('import my_file'))
     assert ret is ImportType.APPLICATION
 
 
 def test_package_existing_is_application_level(in_tmpdir, no_empty_path):
     in_tmpdir.join('my_package').ensure_dir().join('__init__.py').ensure()
-    ret = classify_import('my_package')
+    ret = classify_import(ImportImport.from_str('import my_package'))
     assert ret is ImportType.APPLICATION
 
 
 def test_empty_directory_is_not_package(in_tmpdir, no_empty_path):
     in_tmpdir.join('my_package').ensure_dir()
-    ret = classify_import('my_package')
+    ret = classify_import(ImportImport.from_str('import my_package'))
     assert ret is ImportType.THIRD_PARTY
 
 
@@ -143,10 +153,13 @@ def test_application_directories(in_tmpdir, no_empty_path):
     # Similar to @bukzor's testing setup
     in_tmpdir.join('tests/testing').ensure_dir().join('__init__.py').ensure()
     # Should be classified 3rd party without argument
-    ret = classify_import('testing')
+    ret = classify_import(ImportImport.from_str('import testing'))
     assert ret is ImportType.THIRD_PARTY
     # Should be application with extra directories
-    ret = classify_import('testing', application_directories=('.', 'tests'))
+    ret = classify_import(
+        ImportImport.from_str('import testing'),
+        application_directories=('.', 'tests'),
+    )
     assert ret is ImportType.APPLICATION
 
 
@@ -154,17 +167,21 @@ def test_application_directory_case(in_tmpdir, no_empty_path):
     srcdir = in_tmpdir.join('SRC').ensure_dir()
     srcdir.join('my_package').ensure_dir().join('__init__.py').ensure()
     with in_sys_path('src'):
-        ret = classify_import('my_package', application_directories=('SRC',))
+        ret = classify_import(
+            ImportImport.from_str('import my_package'),
+            application_directories=('SRC',),
+        )
     assert ret is ImportType.APPLICATION
 
 
 def test_unclassifiable_application_modules():
     # Should be classified 3rd party without argument
-    ret = classify_import('c_module')
+    ret = classify_import(ImportImport.from_str('import c_module'))
     assert ret is ImportType.THIRD_PARTY
     # Should be classified application with the override
     ret = classify_import(
-        'c_module', unclassifiable_application_modules=('c_module',),
+        ImportImport.from_str('import c_module'),
+        unclassifiable_application_modules=('c_module',),
     )
     assert ret is ImportType.APPLICATION
 
@@ -172,6 +189,7 @@ def test_unclassifiable_application_modules():
 def test_unclassifiable_application_modules_ignores_future():
     # Trying to force __future__ to be APPLICATION shouldn't have any effect
     ret = classify_import(
-        '__future__', unclassifiable_application_modules=('__future__',),
+        FromImport.from_str('from __future__ import annotations'),
+        unclassifiable_application_modules=('__future__',),
     )
     assert ret is ImportType.FUTURE

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -84,6 +84,21 @@ def test_future_separate_block_non_separate():
     )
 
 
+def test_future_from_always_first():
+    ret = sort(
+        (
+            FromImport.from_str('from __future__ import absolute_import'),
+            ImportImport.from_str('import __future__'),
+        ),
+        separate=False,
+        import_before_from=True,
+    )
+    assert ret == (
+        (FromImport.from_str('from __future__ import absolute_import'),),
+        (ImportImport.from_str('import __future__'),),
+    )
+
+
 def test_passes_through_kwargs_to_classify(in_tmpdir, no_empty_path):
     # Make a module
     in_tmpdir.join('my_module.py').ensure()


### PR DESCRIPTION
Alternative to https://github.com/asottile/aspy.refactor_imports/pull/106 , reworking `classify_import` to take an import object. This is backwards incompatible, there are a few possible uses out there: https://github.com/search?l=Python&q=classify_import&type=Code .

Fixes asottile/reorder_python_imports#214 .