### PR TITLE
avoid slow import of cached_property on py38+

### DIFF
--- a/aspy/refactor_imports/import_obj.py
+++ b/aspy/refactor_imports/import_obj.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import ast
+import sys
 from typing import NamedTuple
 from typing import TypeVar
 from typing import Union
 
-from cached_property import cached_property
+if sys.version_info < (3, 8):  # pragma: <3.8 cover
+    from cached_property import cached_property
+else:  # pragma: >=3.8 cover
+    from functools import cached_property
 
 T = TypeVar('T')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    cached-property
+    cached-property;python_version<"3.8"
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
`cached_property` unconditionally imports `asyncio` which adds ~40ms to startup for no reason